### PR TITLE
fix(mask): fix spotlight masking logic / clip-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frameio/reactour",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Tourist Guide into your React Components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/TourPortal.js
+++ b/src/TourPortal.js
@@ -425,40 +425,70 @@ class TourPortal extends Component {
     const currentStep = steps[current]
 
     return (
-      <Guide
-        isOpen={isOpen}
-        innerRef={this.guideRef}
-        targetHeight={targetHeight}
-        targetWidth={targetWidth}
-        targetTop={targetTop}
-        targetRight={targetRight}
-        targetBottom={targetBottom}
-        targetLeft={targetLeft}
-        windowWidth={windowWidth}
-        windowHeight={windowHeight}
-        helperWidth={helperWidth}
-        helperHeight={helperHeight}
-        helperPosition={helperPosition}
-        padding={maskSpace}
-        tabIndex={-1}
-        current={current}
-        style={currentStep.style ? currentStep.style : {}}
-        rounded={rounded}
-        className={cn(CN.helper.base, className, {
-          [CN.helper.isOpen]: isOpen,
-        })}
-        accentColor={accentColor}
-        pointer={pointer}
-      >
-        {typeof children === 'function'
-          ? children({
-              props: this.props,
-              state: this.state,
-              guideRef: this.guideRef,
-              maskRef: this.maskRef,
-            })
-          : children}
-      </Guide>
+      <React.Fragment>
+        <div
+          ref={this.maskRef}
+          onClick={this.maskClickHandler}
+          className={cn(CN.mask.base, {
+            [CN.mask.isOpen]: isOpen,
+          })}
+        >
+          <SvgMask
+            isOpen={isOpen}
+            windowWidth={windowWidth}
+            windowHeight={windowHeight}
+            targetWidth={targetWidth}
+            targetHeight={targetHeight}
+            targetTop={targetTop}
+            targetLeft={targetLeft}
+            padding={maskSpace}
+            rounded={rounded}
+            className={maskClassName}
+            disableInteraction={
+              disableInteraction && steps[current].stepInteraction
+                ? !steps[current].stepInteraction
+                : disableInteraction
+            }
+            disableInteractionClassName={`${
+              CN.mask.disableInteraction
+            } ${highlightedMaskClassName}`}
+          />
+        </div>
+        <Guide
+          isOpen={isOpen}
+          innerRef={this.guideRef}
+          targetHeight={targetHeight}
+          targetWidth={targetWidth}
+          targetTop={targetTop}
+          targetRight={targetRight}
+          targetBottom={targetBottom}
+          targetLeft={targetLeft}
+          windowWidth={windowWidth}
+          windowHeight={windowHeight}
+          helperWidth={helperWidth}
+          helperHeight={helperHeight}
+          helperPosition={helperPosition}
+          padding={maskSpace}
+          tabIndex={-1}
+          current={current}
+          style={currentStep.style ? currentStep.style : {}}
+          rounded={rounded}
+          className={cn(CN.helper.base, className, {
+            [CN.helper.isOpen]: isOpen,
+          })}
+          accentColor={accentColor}
+          pointer={pointer}
+        >
+          {typeof children === 'function'
+            ? children({
+                props: this.props,
+                state: this.state,
+                guideRef: this.guideRef,
+                maskRef: this.maskRef,
+              })
+            : children}
+        </Guide>
+      </React.Fragment>
     )
   }
 }

--- a/src/components/SvgMask.js
+++ b/src/components/SvgMask.js
@@ -4,7 +4,8 @@ import * as hx from '../helpers'
 import PropTypes from 'prop-types'
 
 const SvgMaskWrapper = styled.div`
-  opacity: 0.7;
+  opacity: ${({ isOpen }) => (isOpen ? 0.7 : 0)};
+  transition: opacity 0.3s ease-in-out;
   width: 100%;
   left: 0;
   top: 0;
@@ -26,6 +27,7 @@ export default function SvgMask({
   disableInteraction,
   disableInteractionClassName,
   className,
+  isOpen,
 }) {
   const width = hx.safe(targetWidth + padding * 2)
   const height = hx.safe(targetHeight + padding * 2)
@@ -33,7 +35,7 @@ export default function SvgMask({
   const left = hx.safe(targetLeft - padding)
 
   return (
-    <SvgMaskWrapper>
+    <SvgMaskWrapper isOpen={isOpen}>
       <svg
         width={windowWidth}
         height={windowHeight}
@@ -108,52 +110,37 @@ export default function SvgMask({
             />
           </mask>
           <clipPath id="clip-path">
-            {/* top */}
-            <rect x={0} y={0} width={windowWidth} height={top} />
-            {/* left */}
-            <rect x={0} y={top} width={left} height={height} />
-            {/* right */}
             <rect
-              x={targetLeft + targetWidth + padding}
+              x={left}
               y={top}
-              width={hx.safe(windowWidth - targetWidth - left)}
+              width={width}
               height={height}
-            />
-            {/* bottom */}
-            <rect
-              x={0}
-              y={targetTop + targetHeight + padding}
-              width={windowWidth}
-              height={hx.safe(windowHeight - targetHeight - top)}
+              style={{ pointerEvents: 'none' }}
+              pointerEvents="auto"
+              fill="transparent"
+              clipRule="evenodd"
             />
           </clipPath>
         </defs>
         <rect
           x={0}
           y={0}
+          style={{ pointerEvents: 'none' }}
           width={windowWidth}
           height={windowHeight}
           fill="#000000"
           mask="url(#mask-main)"
+          clipPath="url(#clip-path)"
         />
         <rect
           x={0}
           y={0}
+          style={{ pointerEvents: 'none' }}
           width={windowWidth}
           height={windowHeight}
           fill="#000000"
-          clipPath="url(#clip-path)"
           pointerEvents="auto"
-        />
-        <rect
-          x={left}
-          y={top}
-          width={width}
-          height={height}
-          pointerEvents="auto"
-          fill="transparent"
-          display={disableInteraction ? 'block' : 'none'}
-          className={disableInteractionClassName}
+          display="none"
         />
       </svg>
     </SvgMaskWrapper>


### PR DESCRIPTION
## GROW-331
- Fix the masking logic via the SVGMask and clip-path
- Allow click events through the mask
- Fade the mask when `isOpen` is toggled

### Screens
<img width="1637" alt="screen shot 2018-08-02 at 5 10 30 pm" src="https://user-images.githubusercontent.com/4651424/43611398-fed5cc12-9676-11e8-935d-05755698108b.png">
